### PR TITLE
Add additional user specific files to ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@ playground.xcworkspace
 # Packages/
 # Package.pins
 # Package.resolved
-# *.xcodeproj
+*.xcodeproj
 #
 # Xcode automatically generates this directory with a .xcworkspacedata file and xcuserdata
 # hence it is not needed unless you have added a package configuration file to your project
@@ -40,7 +40,7 @@ playground.xcworkspace
 # Pods/
 #
 # Add this line if you want to avoid checking in source code from the Xcode workspace
-# *.xcworkspace
+*.xcworkspace
 
 # Carthage
 #
@@ -60,3 +60,13 @@ fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots/**/*.png
 fastlane/test_output
+
+#sample image
+**/sample.imageset/*
+
+# iOS Testing snapshots
+__Snapshots__/
+
+#Archive and device builds
+*.xcarchive
+*.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings


### PR DESCRIPTION
In addition to adding build, archive, workspace folders, the sample image folder for assets is added so that each developer can add its own sample image, note that the image sample aspect ratio is the same as the one taken from a vertical cellular phone.