### PR TITLE
Add empty init constuctor for unknown feed types

### DIFF
--- a/feed_table_view_sample/feed_table_view_sample/Data/FeedLoader.swift
+++ b/feed_table_view_sample/feed_table_view_sample/Data/FeedLoader.swift
@@ -42,7 +42,7 @@ class FeedLoader: FeedLoaderProtocol {
             case FeedType.post.rawValue:
                 return loadPostFeed(datagram)
             default:
-                throw FeedableError.unknownType
+                return loadUnknowFeed()
         }
     }
 
@@ -82,6 +82,10 @@ class FeedLoader: FeedLoaderProtocol {
         return result
     }
 
+    func loadUnknowFeed() -> FeedModel {
+        return FeedModel()
+    }
+
     func loadTextFeed(_ textDatagram: [String:String]) -> FeedModel? {
         guard let fields = extractRequiredFields(
             textDatagram,
@@ -94,7 +98,6 @@ class FeedLoader: FeedLoaderProtocol {
             type: fields["type"]!,
             isoCreatedAt: fields["isoCreatedAt"]!
         )
-
     }
 
     func loadPostFeed(_ postDatagram: [String:String]) -> FeedModel? {

--- a/feed_table_view_sample/feed_table_view_sample/Model/FeedModel.swift
+++ b/feed_table_view_sample/feed_table_view_sample/Model/FeedModel.swift
@@ -34,4 +34,11 @@ class FeedModel: FeedProtocol {
         self.createdAt = ISO8601DateFormatter().date(from: isoCreatedAt) ?? Date()
     }
 
+    init() {
+        self.author = "Unknown"
+        self.title = "No title"
+        self.type = FeedType.unknown
+        self.createdAt = Date()
+    }
+
 }


### PR DESCRIPTION
Update the feed loader to instead return an unknown feed model and not throw an error.