### PR TITLE
Implement app context

### DIFF
--- a/feed_table_view_sample/feed_table_view_sample/AppDelegate.swift
+++ b/feed_table_view_sample/feed_table_view_sample/AppDelegate.swift
@@ -12,6 +12,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
+        AppContextManager.app.configure(with: FakeAppContext())
         return true
     }
 


### PR DESCRIPTION
Given that the app context will remain the same no matter if the app has multiple scenes and will be loaded just once it is best to call it during app launch.