### PR TITLE
Add properties to protocol to make it more testable and decoupled

### DIFF
--- a/feed_table_view_sample/feed_table_view_sample/Data/FeedLoaderProtocol.swift
+++ b/feed_table_view_sample/feed_table_view_sample/Data/FeedLoaderProtocol.swift
@@ -14,6 +14,9 @@ enum FeedableError: Error, Equatable {
 }
 
 protocol FeedLoaderProtocol {
-    func loadAllFeeds(data: [[String:String]]) throws -> [FeedModel]
-    func loadSingleFeed(_ datagram: [String:String]) throws -> FeedModel?
+    var data: [FeedDatagram]? { get }
+    var feeds: [FeedModel]? { get }
+    func loadData() async throws //Use it to load data
+    func loadAllFeeds() throws //Use it to load feeds
+    func loadSingleFeed(_ datagram: FeedDatagram) throws -> FeedModel?
 }


### PR DESCRIPTION
New properties allow any class conforming to the protocol to get access to its data and its feeds while also being able to load data internally, load the feeds internally or load a single feed based using the decoded FeedDatagram.